### PR TITLE
Fix the display of dialogs when changing orientation.

### DIFF
--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/DialogView.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/DialogView.kt
@@ -1,38 +1,10 @@
 package com.ssepulveda.swearwords.ui.screens
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieClipSpec
-import com.airbnb.lottie.compose.LottieCompositionSpec
-import com.airbnb.lottie.compose.animateLottieCompositionAsState
-import com.airbnb.lottie.compose.rememberLottieComposition
-import com.ssepulveda.swearwords.R
+import com.ssepulveda.swearwords.ui.screens.dialogs.ErrorDialog
+import com.ssepulveda.swearwords.ui.screens.dialogs.SuccessDialog
 import com.ssepulveda.swearwords.ui.theme.SwearWordsTheme
 import com.ssepulveda.swearwords.viewModels.MainViewModel
 
@@ -40,12 +12,9 @@ import com.ssepulveda.swearwords.viewModels.MainViewModel
 fun InitDialog(mainViewModel: MainViewModel = viewModel()) {
     if (!mainViewModel.uiDialog.onDialogError.isNullOrBlank()) {
         ErrorDialog(
-            mainViewModel.uiDialog.onDialogError.orEmpty(),
-            {
-                mainViewModel.onCloseDialog()
-            }, {
-                mainViewModel.onClearTextDismissDialog()
-            }
+            message = mainViewModel.uiDialog.onDialogError.orEmpty(),
+            onDismissRequestAction = mainViewModel::onCloseDialog,
+            onClearAction = mainViewModel::onClearTextDismissDialog
         )
     }
     if (mainViewModel.uiDialog.onDialogSuccess) {
@@ -54,171 +23,6 @@ fun InitDialog(mainViewModel: MainViewModel = viewModel()) {
         }
     }
 }
-
-@Composable
-fun SuccessDialog(
-    onDismissRequestAction: () -> Unit = {}
-) {
-    Dialog(onDismissRequest = onDismissRequestAction) {
-        Card(
-            elevation = 8.dp,
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Column {
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .background(Color.Green)
-                        .height(160.dp)
-                ) {
-                    LottieGood()
-                }
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    Text(
-                        text = "¡Bien hecho!",
-                        style = MaterialTheme.typography.h1
-
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "Este texto no tiene palabrotas",
-                        style = MaterialTheme.typography.body2,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 12.dp
-                        )
-                    )
-                }
-                Row(
-                    horizontalArrangement = Arrangement.End,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    TextButton(onClick = onDismissRequestAction) {
-                        Text(
-                            text = "OK",
-                            style = MaterialTheme.typography.button
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun ErrorDialog(
-    message: String,
-    onDismissRequestAction: () -> Unit = {},
-    onClearAction: () -> Unit = {}
-) {
-    Dialog(onDismissRequest = onDismissRequestAction) {
-        Card(
-            elevation = 8.dp,
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Column {
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .background(Color.Red)
-                        .height(160.dp)
-                ) {
-                    LottieError()
-                }
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    Text(
-                        text = "¡Oops!",
-                        style = MaterialTheme.typography.h1,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "Lo sentimos!, Este texto tiene palabrotas :( ",
-                        style = MaterialTheme.typography.body2,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 12.dp
-                        )
-                    )
-                    Text(
-                        text = message,
-                        style = MaterialTheme.typography.caption,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 12.dp,
-                            bottom = 12.dp
-                        )
-                    )
-                }
-                Row(
-                    horizontalArrangement = Arrangement.End,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    TextButton(onClick = onClearAction) {
-                        Text(
-                            text = "Limpiar",
-                            style = MaterialTheme.typography.button,
-                        )
-                    }
-
-                    TextButton(onClick = onDismissRequestAction) {
-                        Text(
-                            text = "OK",
-                            style = MaterialTheme.typography.button,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun LottieGood() {
-    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.good))
-    val progress by animateLottieCompositionAsState(
-        composition,
-        clipSpec = LottieClipSpec.Progress(0.0f, 0.7f)
-    )
-    LottieAnimation(
-        composition,
-        progress,
-        modifier = Modifier.fillMaxSize(),
-    )
-}
-
-@Composable
-fun LottieError() {
-    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.fail))
-    val progress by animateLottieCompositionAsState(
-        composition,
-        clipSpec = LottieClipSpec.Progress(0.0f, 0.48f),
-    )
-    LottieAnimation(
-        composition,
-        progress,
-        modifier = Modifier.fillMaxSize(),
-    )
-}
-
 
 @Preview(showBackground = false)
 @Composable

--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/HomeView.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/HomeView.kt
@@ -1,24 +1,15 @@
 package com.ssepulveda.swearwords.ui.screens
 
-import android.content.res.Configuration
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ssepulveda.swearwords.viewModels.MainViewModel
 
 @Composable
 fun ScreenHome(mainViewModel: MainViewModel = viewModel()) {
-    val configuration = LocalConfiguration.current
-    when (configuration.orientation) {
-        Configuration.ORIENTATION_LANDSCAPE -> {
-            //Text("Landscape")
-            InitFormLandscape(mainViewModel)
-        }
-        else -> {
-            //Text("Portrait")
-            InitFormPortrait(mainViewModel)
-        }
-    }
+    OrientationView(
+        composableLandscape = { InitFormLandscape(mainViewModel) },
+        composablePortrait = { InitFormPortrait(mainViewModel) }
+    )
     AddLoading(mainViewModel)
     InitDialog(mainViewModel)
 }

--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/OrientationView.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/OrientationView.kt
@@ -1,0 +1,21 @@
+package com.ssepulveda.swearwords.ui.screens
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+
+@Composable
+fun OrientationView(
+    composableLandscape: @Composable () -> Unit,
+    composablePortrait: @Composable () -> Unit
+) {
+    val configuration = LocalConfiguration.current
+    when (configuration.orientation) {
+        Configuration.ORIENTATION_LANDSCAPE -> {
+            composableLandscape()
+        }
+        else -> {
+            composablePortrait()
+        }
+    }
+}

--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/animations.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/animations.kt
@@ -1,0 +1,36 @@
+package com.ssepulveda.swearwords.ui.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.airbnb.lottie.compose.*
+import com.ssepulveda.swearwords.R
+
+@Composable
+fun LottieError() {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.fail))
+    val progress by animateLottieCompositionAsState(
+        composition,
+        clipSpec = LottieClipSpec.Progress(0.0f, 0.48f),
+    )
+    LottieAnimation(
+        composition,
+        progress,
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@Composable
+fun LottieGood() {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.good))
+    val progress by animateLottieCompositionAsState(
+        composition,
+        clipSpec = LottieClipSpec.Progress(0.0f, 0.7f)
+    )
+    LottieAnimation(
+        composition,
+        progress,
+        modifier = Modifier.fillMaxSize(),
+    )
+}

--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/dialogs/ErrorDialog.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/dialogs/ErrorDialog.kt
@@ -1,0 +1,204 @@
+package com.ssepulveda.swearwords.ui.screens.dialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.ssepulveda.swearwords.ui.screens.LottieError
+import com.ssepulveda.swearwords.ui.screens.OrientationView
+
+@Composable
+fun ErrorDialog(
+    message: String,
+    onDismissRequestAction: () -> Unit = {},
+    onClearAction: () -> Unit = {}
+) {
+    Dialog(
+        onDismissRequest = onDismissRequestAction,
+    ) {
+
+        OrientationView(
+            composableLandscape = {
+                ErrorDialogLandscape(
+                    message,
+                    onClearAction,
+                    onDismissRequestAction
+                )
+            },
+            composablePortrait = {
+                ErrorDialogPortrait(
+                    message,
+                    onClearAction,
+                    onDismissRequestAction
+                )
+            }
+        )
+    }
+}
+
+@Composable
+private fun ErrorDialogLandscape(
+    message: String,
+    onClearAction: () -> Unit,
+    onDismissRequestAction: () -> Unit
+) {
+    Card(
+        elevation = 8.dp,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(0.85f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ErrorDialogAnimation(ModifierDialogError.ANIMATION_LANDSCAPE.modifier)
+                InformationText(message, ModifierDialogError.INFORMATION_LANDSCAPE.modifier)
+            }
+            keypadDialog(
+                Modifier
+                    .fillMaxHeight()
+                    .align(Alignment.End)
+                    .weight(0.15f),
+                onClearAction,
+                onDismissRequestAction
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorDialogPortrait(
+    message: String,
+    onClearAction: () -> Unit,
+    onDismissRequestAction: () -> Unit
+) {
+    Card(
+        elevation = 8.dp,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            ErrorDialogAnimation(ModifierDialogError.ANIMATION_PORTRAIT.modifier)
+            InformationText(message, ModifierDialogError.INFORMATION_PORTRAIT.modifier)
+            keypadDialog(
+                ModifierDialogError.KEYPAD_PORTRAIT.modifier,
+                onClearAction,
+                onDismissRequestAction
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorDialogAnimation(customModifier: Modifier) {
+    Box(modifier = customModifier) {
+        LottieError()
+    }
+}
+
+@Composable
+private fun keypadDialog(
+    customModifier: Modifier,
+    onClearAction: () -> Unit,
+    onDismissRequestAction: () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = customModifier
+    ) {
+        ButtonText("Limpiar", onClearAction)
+        ButtonText("OK", onDismissRequestAction)
+    }
+}
+
+@Composable
+private fun ButtonText(text: String, action: () -> Unit) {
+    TextButton(onClick = action) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.button,
+        )
+    }
+}
+
+@Composable
+private fun InformationText(message: String, CustomModifier: Modifier) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = CustomModifier
+    ) {
+        Text(
+            text = "¡Oops!",
+            style = MaterialTheme.typography.h1,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Lo sentimos!, Este texto tiene palabrotas :( ",
+            style = MaterialTheme.typography.body2,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 12.dp
+            )
+        )
+        Text(
+            text = message,
+            style = MaterialTheme.typography.caption,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 12.dp,
+                bottom = 12.dp
+            )
+        )
+    }
+}
+
+enum class ModifierDialogError(val modifier: Modifier) {
+    ANIMATION_PORTRAIT(
+        Modifier
+            .fillMaxWidth()
+            .background(Color.Red)
+            .height(160.dp)
+    ),
+    INFORMATION_PORTRAIT(
+        Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ),
+    KEYPAD_PORTRAIT(
+        Modifier.fillMaxWidth()
+    ),
+    ANIMATION_LANDSCAPE(
+        Modifier
+            .padding(top = 12.dp)
+            .size(90.dp)
+            .clip(CircleShape)
+            .background(Color.Red)
+    ),
+    INFORMATION_LANDSCAPE(
+        Modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .padding(PaddingValues(16.dp, 12.dp, 16.dp, 4.dp))
+    )
+}

--- a/app/src/main/java/com/ssepulveda/swearwords/ui/screens/dialogs/SuccessDialog.kt
+++ b/app/src/main/java/com/ssepulveda/swearwords/ui/screens/dialogs/SuccessDialog.kt
@@ -1,0 +1,129 @@
+package com.ssepulveda.swearwords.ui.screens.dialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.ssepulveda.swearwords.ui.screens.LottieGood
+import com.ssepulveda.swearwords.ui.screens.OrientationView
+
+@Composable
+fun SuccessDialog(
+    onDismissRequestAction: () -> Unit = {}
+) {
+    Dialog(onDismissRequest = onDismissRequestAction) {
+        Card(
+            elevation = 8.dp,
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            OrientationView(
+                composableLandscape = {
+                    SuccessDialogLandscape(onDismissRequestAction)
+                },
+                composablePortrait = {
+                    SuccessDialogPortrait(onDismissRequestAction)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SuccessDialogPortrait(onDismissRequestAction: () -> Unit) {
+    Column {
+        DialogAnimationSuccess(ModifierDialogSuccess.ANIMATION_PORTRAIT.modifier)
+        TextInformation()
+        KeyPadDialog(onDismissRequestAction)
+    }
+}
+
+@Composable
+private fun SuccessDialogLandscape(onDismissRequestAction: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        DialogAnimationSuccess(ModifierDialogSuccess.ANIMATION_LANDSCAPE.modifier)
+        TextInformation()
+        KeyPadDialog(onDismissRequestAction)
+    }
+}
+
+@Composable
+private fun TextInformation() {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "¡Bien hecho!",
+            style = MaterialTheme.typography.h1
+
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Este texto no tiene palabrotas",
+            style = MaterialTheme.typography.body2,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 12.dp
+            )
+        )
+    }
+}
+
+@Composable
+private fun KeyPadDialog(onDismissRequestAction: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        TextButton(onClick = onDismissRequestAction) {
+            Text(
+                text = "OK",
+                style = MaterialTheme.typography.button
+            )
+        }
+    }
+}
+
+@Composable
+private fun DialogAnimationSuccess(customModifier: Modifier) {
+    Box(
+        modifier = customModifier
+    ) {
+        LottieGood()
+    }
+}
+
+enum class ModifierDialogSuccess(val modifier: Modifier) {
+    ANIMATION_PORTRAIT(
+        Modifier
+            .fillMaxWidth()
+            .background(Color.Green)
+            .height(160.dp)
+    ),
+    ANIMATION_LANDSCAPE(
+        Modifier
+            .padding(top = 12.dp)
+            .size(90.dp)
+            .clip(CircleShape)
+            .background(Color.Green)
+    )
+}


### PR DESCRIPTION
the **OrientationView** method is created to facilitate the use of orientation with jetpackCompose
```
  OrientationView(
                composableLandscape = {
                    SuccessDialogLandscape(onDismissRequestAction)
                },
                composablePortrait = {
                    SuccessDialogPortrait(onDismissRequestAction)
                }
  )
```

This method receives two parameters **composableLandscape** and **composablePortrait** in which the view display is defined depending on the orientation.